### PR TITLE
fix: update metrics for disk space

### DIFF
--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -267,13 +267,13 @@
           {
             record: 'node:disk_space_available:',
             expr: |||
-              sum(max(node_filesystem_avail_bytes{device=~"/dev/[vsh]d.+", %(nodeExporterSelector)s} * on (namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:) by (device, node)) by (node)
+              sum(max(node_filesystem_avail_bytes{device=~"/dev/.*", %(nodeExporterSelector)s} * on (namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:) by (device, node)) by (node)
             ||| % $._config,
           },
           {
             record: 'node:disk_space_utilization:ratio',
             expr: |||
-              1- sum(max(node_filesystem_avail_bytes{device=~"/dev/[vsh]d.+", %(nodeExporterSelector)s} * on (namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:) by (device, node)) by (node) / sum(max(node_filesystem_size_bytes{device=~"/dev/[vsh]d.+", %(nodeExporterSelector)s} * on (namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:) by (device, node)) by (node)
+              1- sum(max(node_filesystem_avail_bytes{device=~"/dev/.*", %(nodeExporterSelector)s} * on (namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:) by (device, node)) by (node) / sum(max(node_filesystem_size_bytes{device=~"/dev/.*", %(nodeExporterSelector)s} * on (namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:) by (device, node)) by (node)
             ||| % $._config,
           },
           {
@@ -320,7 +320,7 @@
           {
             record: 'cluster:disk_utilization:ratio',
             expr: |||
-              1 - sum(max(node_filesystem_avail_bytes{device=~"/dev/[vsh]d.+", %(nodeExporterSelector)s}) by (device, instance)) / sum(max(node_filesystem_size_bytes{device=~"/dev/[vsh]d.+", %(nodeExporterSelector)s}) by (device, instance))
+              1 - sum(max(node_filesystem_avail_bytes{device=~"/dev/.*", %(nodeExporterSelector)s}) by (device, instance)) / sum(max(node_filesystem_size_bytes{device=~"/dev/.*", %(nodeExporterSelector)s}) by (device, instance))
             ||| % $._config,
           },
           {


### PR DESCRIPTION
We miss many types of storage devices when calculating disk space metrics, such as lvm logical volumes (/dev/mapper/\*), software RAID devices (/dev/md\*), Xen virtual block device (/dev/xvd\*). 

The new way of calculating extends the filter range to include all permanent storage devices.