### PR TITLE
add role label only if it's master

### DIFF
--- a/rules/kubesphere.libsonnet
+++ b/rules/kubesphere.libsonnet
@@ -52,7 +52,7 @@
             // it is used to calculate per-node metrics, given namespace & instance.
             record: 'node_namespace_pod:kube_pod_info:',
             expr: |||
-              max(kube_pod_info{%(kubeStateMetricsSelector)s} * on(node) group_left(role) kube_node_role{%(kubeStateMetricsSelector)s}) by (node, namespace, host_ip, role, %(podLabel)s)
+              max(kube_pod_info{%(kubeStateMetricsSelector)s} * on(node) group_left(role) kube_node_role{%(kubeStateMetricsSelector)s, role="master"} or on(%(podLabel)s, namespace) kube_pod_info{%(kubeStateMetricsSelector)s}) by (node, namespace, host_ip, role, %(podLabel)s)
             ||| % $._config,
           },
           {


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

Only add role label if node is master.

This is to avoid many-to-many matching when the node is more than a master.

![image](https://user-images.githubusercontent.com/22350668/85252272-fd394a00-b48d-11ea-9e4e-c6e1a393c549.png)
