### PR TITLE
fix selector for kube_node_status_allocatable_memory_bytes

### DIFF
--- a/alerts/resource_alerts.libsonnet
+++ b/alerts/resource_alerts.libsonnet
@@ -79,7 +79,7 @@
             expr: |||
               sum(kube_resourcequota{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s, type="hard", resource="memory"})
                 /
-              sum(kube_node_status_allocatable_memory_bytes{%(nodeExporterSelector)s})
+              sum(kube_node_status_allocatable_memory_bytes{%(prefixedNamespaceSelector)s%(kubeStateMetricsSelector)s})
                 > %(namespaceOvercommitFactor)s
             ||| % $._config,
             labels: {


### PR DESCRIPTION
follow the upstream fix:  https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/514

/assign @benjaminhuo 